### PR TITLE
Feature/gb adding repo self checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/*
 yarn.lock
+.vscode/*

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Make sure that you have your git account setup locally since it'll run `git` com
 
 ### Args
 
+#### `--gitUrl` (string)
+
+The `.git` url for the repo you are running the merge commands agains't. Keep in mind that the username on the git url must have permission to pull and push change to the repo
+
 #### `--branchPrefixList` (string list space - delimited)
 
 Will scope your branch list for merging based on the naming specified.

--- a/index.js
+++ b/index.js
@@ -222,19 +222,16 @@
    * @param {String} url
    */
   const cloneRepo = async url => {
-    if (!gitUrl) {
+    if (!url) {
       throw new Error("There is no specified git URL");
     }
-    if (!push) {
-      console.info(`[DRY-RUN]: git clone ${gitUrl}`);
-      console.info("[DRY-RUN]: cd *");
-    }
 
-    await execPromise(`git clone ${gitUrl}`);
-    await execPromise("cd *");
+    await execPromise(`git clone ${gitUrl} repo`);
+    process.chdir("repo");
   };
 
   try {
+    await cloneRepo(gitUrl);
     await execPromise("git fetch -p");
     await setupMergeStrategy();
     const branchNames = await getBranchNames();

--- a/index.js
+++ b/index.js
@@ -1,16 +1,20 @@
 (async () => {
-  const { dev, branchPrefixList, push, masterBranch } = require("minimist")(
-    process.argv.slice(2),
-    {
-      boolean: ["dev", "push"],
-      default: {
-        dev: false,
-        push: false,
-        branchPrefixList: "",
-        masterBranch: ""
-      }
+  const {
+    gitUrl,
+    dev,
+    branchPrefixList,
+    push,
+    masterBranch
+  } = require("minimist")(process.argv.slice(2), {
+    boolean: ["dev", "push"],
+    default: {
+      gitUrl: "",
+      dev: false,
+      push: false,
+      branchPrefixList: "",
+      masterBranch: ""
     }
-  );
+  });
 
   const exec = require("child_process").exec;
   const semver = require("semver");
@@ -211,6 +215,23 @@
       await pushBranch(branchMap.mergeInto);
     }
     /* eslint-enable no-await-in-loop */
+  };
+
+  /**
+   * Clones the repo and cd's into the directory
+   * @param {String} url
+   */
+  const cloneRepo = async url => {
+    if (!gitUrl) {
+      throw new Error("There is no specified git URL");
+    }
+    if (!push) {
+      console.info(`[DRY-RUN]: git clone ${gitUrl}`);
+      console.info("[DRY-RUN]: cd *");
+    }
+
+    await execPromise(`git clone ${gitUrl}`);
+    await execPromise("cd *");
   };
 
   try {


### PR DESCRIPTION
Adding logic to allow this repo to clone other repos and run the git merge logic only on the pulled repo. This could then be used within a Jenkins or CircleCI pipeline to run auto merges outside of the codebase that is getting merged.